### PR TITLE
Tie AE decoder weights to encoder

### DIFF
--- a/configs/model/deepfont_ae.yaml
+++ b/configs/model/deepfont_ae.yaml
@@ -16,6 +16,7 @@ encoder_kernel_sizes: [11, 5]
 encoder_strides: [2, 1]
 encoder_paddings: [0, 2]
 pool_kernel_size: 2
+tied_weights: true
 
 # Output
 output_activation: null  # null | "sigmoid" | "relu"

--- a/deepfont/models/config.py
+++ b/deepfont/models/config.py
@@ -97,6 +97,18 @@ class DeepFontAEConfig(BaseModel):
         ge=1,
         description="Kernel size for MaxPool2d applied after each encoder conv stage.",
     )
+    tied_weights: bool = Field(
+        default=True,
+        description=(
+            "If True, the decoder reuses the encoder's Conv2d weights via "
+            "F.conv_transpose2d so that each encoder filter and its matching "
+            "decoder filter are constrained to be transposes of each other. "
+            "This follows the original Masci 2011 stacked convolutional "
+            "auto-encoder formulation cited by the DeepFont paper. The "
+            "decoder still owns its own per-stage bias parameters. When "
+            "False, each decoder stage uses an independent ConvTranspose2d."
+        ),
+    )
 
     # Output
     output_activation: Literal["sigmoid", "relu"] | None = Field(

--- a/deepfont/models/deepfont.py
+++ b/deepfont/models/deepfont.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F  # noqa: N812
 
 from .config import DeepFontConfig, DeepFontAEConfig
 
@@ -35,6 +36,80 @@ def _make_norm_layer(
     if norm_type == "batch":
         return nn.BatchNorm2d(num_channels)
     raise ValueError(f"Unknown norm_type '{norm_type}'. Expected 'none', 'lrn', or 'batch'.")
+
+
+class TiedConvTranspose2d(nn.Module):
+    """Transposed convolution whose weight is tied to a paired encoder Conv2d.
+
+    The decoder layer reuses the weight tensor of an encoder Conv2d via
+    F.conv_transpose2d at forward time, constraining the encoder filter and
+    decoder filter to be transposes of each other. This follows the original
+    Masci 2011 stacked convolutional auto-encoder formulation cited by the
+    DeepFont paper.
+
+    A Conv2d weight has shape (out_channels, in_channels, kH, kW), which is
+    exactly the layout F.conv_transpose2d expects when going in the reverse
+    direction (in_channels and out_channels swap roles for the transpose), so
+    no reshaping is needed.
+
+    The decoder layer still owns its own bias parameter; only the weight is
+    shared. Gradients flow back into the encoder Conv2d's weight from both
+    the encoder and decoder paths during backward, which keeps the tying
+    consistent through training.
+
+    Attributes:
+        encoder_conv: The encoder Conv2d whose weight is reused. Stored as a
+            plain attribute (not a child module) to avoid the encoder weight
+            being registered twice in the decoder's state_dict.
+        stride: Stride for the transposed convolution.
+        padding: Padding for the transposed convolution.
+        bias: Per-output-channel bias parameter owned by this layer.
+    """
+
+    encoder_conv: nn.Conv2d
+
+    def __init__(self, encoder_conv: nn.Conv2d, stride: int, padding: int):
+        """Initialize a tied transposed convolution paired with an encoder Conv2d.
+
+        Args:
+            encoder_conv: The encoder Conv2d whose weight tensor will be reused
+                as the transposed-conv filter. Its weight shape determines the
+                input and output channel counts of this layer (in_channels and
+                out_channels swap relative to the encoder).
+            stride: Stride for the transposed convolution. Should match the
+                paired encoder Conv2d's stride.
+            padding: Padding for the transposed convolution. Should match the
+                paired encoder Conv2d's padding.
+        """
+        super().__init__()
+        # Avoid registering the encoder Conv2d as a child module so its weight
+        # is not duplicated in this layer's state_dict, but keep a live
+        # reference so weight updates remain visible at forward time.
+        object.__setattr__(self, "encoder_conv", encoder_conv)
+        self.stride = stride
+        self.padding = padding
+        # ConvTranspose2d output channels equal the paired Conv2d's
+        # in_channels because the channel direction flips in the transpose.
+        self.bias = nn.Parameter(torch.zeros(encoder_conv.in_channels))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the tied transposed convolution to x."""
+        return F.conv_transpose2d(
+            x,
+            self.encoder_conv.weight,
+            bias=self.bias,
+            stride=self.stride,
+            padding=self.padding,
+        )
+
+    def extra_repr(self) -> str:
+        w = self.encoder_conv.weight
+        out_ch, in_ch, kh, kw = w.shape
+        return (
+            f"in_channels={out_ch}, out_channels={in_ch}, "
+            f"kernel_size=({kh}, {kw}), stride={self.stride}, "
+            f"padding={self.padding}, tied=True"
+        )
 
 
 def _build_encoder(
@@ -77,6 +152,11 @@ def _build_encoder(
     return nn.Sequential(*layers)
 
 
+def _encoder_conv_layers(encoder: nn.Sequential) -> list[nn.Conv2d]:
+    """Return the Conv2d layers in encoder order."""
+    return [m for m in encoder if isinstance(m, nn.Conv2d)]
+
+
 def _build_decoder(
     out_channels: int,
     encoder_channels: tuple[int, ...],
@@ -85,6 +165,7 @@ def _build_decoder(
     encoder_paddings: tuple[int, ...],
     pool_kernel_size: int,
     output_activation: str | None,
+    encoder_convs: list[nn.Conv2d] | None = None,
 ) -> nn.Sequential:
     """Build a decoder that mirrors the encoder structure.
 
@@ -92,10 +173,13 @@ def _build_decoder(
     Upsample -> ConvTranspose2d -> ReLU, except the final layer which
     omits the ReLU (or replaces it with the requested output_activation).
 
-    The ConvTranspose2d at each stage uses the same kernel size, stride,
-    and padding as its corresponding encoder Conv2d, which ensures the
-    transpose convolution inverts the spatial transform of the forward
-    convolution.
+    The transposed convolution at each stage uses the same kernel size,
+    stride, and padding as its corresponding encoder Conv2d, which ensures
+    the transpose inverts the spatial transform of the forward convolution.
+
+    When encoder_convs is provided, each decoder stage is built with a
+    TiedConvTranspose2d that reuses the paired encoder Conv2d's weight.
+    Otherwise an independent ConvTranspose2d is used at each stage.
 
     Args:
         out_channels: Number of channels the decoder should produce (typically
@@ -106,6 +190,9 @@ def _build_decoder(
         encoder_paddings: Paddings from the encoder (in encoder order).
         pool_kernel_size: Pool kernel size used in the encoder.
         output_activation: Optional final activation ("sigmoid" or "relu").
+        encoder_convs: When not None, the encoder's Conv2d layers in encoder
+            order. Each decoder stage will tie its weight to the matching
+            encoder Conv2d via TiedConvTranspose2d.
 
     Returns:
         An nn.Sequential module implementing the decoder.
@@ -116,6 +203,14 @@ def _build_decoder(
     reversed_kernel_sizes = list(reversed(encoder_kernel_sizes))
     reversed_strides = list(reversed(encoder_strides))
     reversed_paddings = list(reversed(encoder_paddings))
+    if encoder_convs is not None:
+        if len(encoder_convs) != n_stages:
+            raise ValueError(
+                f"encoder_convs has {len(encoder_convs)} layers but encoder has {n_stages} stages."
+            )
+        reversed_convs = list(reversed(encoder_convs))
+    else:
+        reversed_convs = None
 
     for i in range(n_stages):
         in_ch = reversed_channels[i]
@@ -127,8 +222,11 @@ def _build_decoder(
 
         # Upsample to undo the MaxPool2d
         layers.append(nn.Upsample(scale_factor=pool_kernel_size))
-        # ConvTranspose2d to undo the Conv2d
-        layers.append(nn.ConvTranspose2d(in_ch, target_ch, kernel_size=k, stride=s, padding=p))
+        # Transposed conv (tied or independent) to undo the Conv2d
+        if reversed_convs is not None:
+            layers.append(TiedConvTranspose2d(reversed_convs[i], stride=s, padding=p))
+        else:
+            layers.append(nn.ConvTranspose2d(in_ch, target_ch, kernel_size=k, stride=s, padding=p))
 
         # Add activation (ReLU for intermediate layers, optional for last)
         is_last = i == n_stages - 1
@@ -210,6 +308,7 @@ class DeepFontAE(nn.Module):
             pool_kernel_size=config.pool_kernel_size,
             norm_type="none",
         )
+        encoder_convs = _encoder_conv_layers(self.encoder) if config.tied_weights else None
         self.decoder = _build_decoder(
             out_channels=config.in_channels,
             encoder_channels=config.encoder_channels,
@@ -218,6 +317,7 @@ class DeepFontAE(nn.Module):
             encoder_paddings=config.encoder_paddings,
             pool_kernel_size=config.pool_kernel_size,
             output_activation=config.output_activation,
+            encoder_convs=encoder_convs,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 import pytest
 
 from deepfont.models.config import DeepFontAEConfig, DeepFontConfig
-from deepfont.models.deepfont import DeepFontAE, DeepFont
+from deepfont.models.deepfont import DeepFontAE, DeepFont, TiedConvTranspose2d
 
 # Module-level constants
 
@@ -218,8 +218,12 @@ class TestDeepFontAEArchitecture:
         assert _count_layer_types(model.encoder, nn.LocalResponseNorm) == 0
 
     def test_decoder_has_conv_transpose_layers(self):
-        """Decoder contains ConvTranspose2d layers matching encoder stages."""
-        config = _small_ae_config()
+        """Decoder contains ConvTranspose2d layers matching encoder stages.
+
+        Uses tied_weights=False because the default tied variant uses
+        TiedConvTranspose2d, not nn.ConvTranspose2d.
+        """
+        config = _small_ae_config(tied_weights=False)
         model = DeepFontAE(config)
         n_deconv = _count_layer_types(model.decoder, nn.ConvTranspose2d)
         assert n_deconv == len(config.encoder_channels)
@@ -259,15 +263,193 @@ class TestDeepFontAEArchitecture:
             encoder_kernel_sizes=(7, 5, 3),
             encoder_strides=(1, 1, 1),
             encoder_paddings=(3, 2, 1),
+            tied_weights=False,
         )
         model = DeepFontAE(config)
         assert _count_layer_types(model.encoder, nn.Conv2d) == 3
         assert _count_layer_types(model.decoder, nn.ConvTranspose2d) == 3
 
+    def test_three_stage_encoder_decoder_tied(self):
+        """Three-stage config with tied weights produces matching tied layers."""
+        config = DeepFontAEConfig(
+            encoder_channels=(32, 64, 128),
+            encoder_kernel_sizes=(7, 5, 3),
+            encoder_strides=(1, 1, 1),
+            encoder_paddings=(3, 2, 1),
+            tied_weights=True,
+        )
+        model = DeepFontAE(config)
+        assert _count_layer_types(model.encoder, nn.Conv2d) == 3
+        assert _count_layer_types(model.decoder, TiedConvTranspose2d) == 3
+        # Tied decoder must not introduce any independent ConvTranspose2d.
+        assert _count_layer_types(model.decoder, nn.ConvTranspose2d) == 0
+
     def test_all_parameters_are_trainable(self):
         """All parameters require gradients by default."""
         model = DeepFontAE()
         assert all(p.requires_grad for p in model.parameters())
+
+
+class TestDeepFontAETiedWeights:
+    """Weight tying between the encoder Conv2d layers and the decoder."""
+
+    def test_tied_default_is_true(self):
+        """The tied_weights field defaults to True."""
+        assert DeepFontAEConfig().tied_weights is True
+
+    def test_tied_decoder_uses_tied_modules(self):
+        """When tied_weights=True the decoder uses TiedConvTranspose2d."""
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        n_tied = _count_layer_types(model.decoder, TiedConvTranspose2d)
+        n_untied = _count_layer_types(model.decoder, nn.ConvTranspose2d)
+        assert n_tied == len(model.config.encoder_channels)
+        assert n_untied == 0
+
+    def test_untied_decoder_uses_independent_modules(self):
+        """When tied_weights=False the decoder uses nn.ConvTranspose2d."""
+        model = DeepFontAE(_small_ae_config(tied_weights=False))
+        n_tied = _count_layer_types(model.decoder, TiedConvTranspose2d)
+        n_untied = _count_layer_types(model.decoder, nn.ConvTranspose2d)
+        assert n_tied == 0
+        assert n_untied == len(model.config.encoder_channels)
+
+    def test_decoder_weights_share_storage_with_encoder(self):
+        """Each tied decoder layer's weight is the same tensor as its encoder Conv2d weight."""
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        encoder_convs = [m for m in model.encoder if isinstance(m, nn.Conv2d)]
+        tied_layers = [m for m in model.decoder if isinstance(m, TiedConvTranspose2d)]
+        # Decoder mirrors the encoder, so pair encoder[i] with decoder[-1-i].
+        assert len(encoder_convs) == len(tied_layers)
+        for enc, dec in zip(encoder_convs, reversed(tied_layers), strict=True):
+            assert dec.encoder_conv is enc
+            assert dec.encoder_conv.weight.data_ptr() == enc.weight.data_ptr()
+
+    def test_tied_decoder_has_no_weight_in_state_dict(self):
+        """Tied decoder layers contribute only their bias to the state_dict."""
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        decoder_keys = [k for k in model.state_dict() if k.startswith("decoder.")]
+        # Tied decoder must not duplicate any encoder weights.
+        assert not any(k.endswith(".weight") for k in decoder_keys)
+        # One bias per encoder stage.
+        bias_keys = [k for k in decoder_keys if k.endswith(".bias")]
+        assert len(bias_keys) == len(model.config.encoder_channels)
+
+    def test_tied_model_has_fewer_parameters_than_untied(self):
+        """Tying reduces the parameter count by the decoder weight sizes."""
+        tied = DeepFontAE(_small_ae_config(tied_weights=True))
+        untied = DeepFontAE(_small_ae_config(tied_weights=False))
+        n_tied = sum(p.numel() for p in tied.parameters())
+        n_untied = sum(p.numel() for p in untied.parameters())
+        # The savings equal the encoder Conv2d weight tensor sizes.
+        encoder_conv_weights = sum(
+            m.weight.numel() for m in tied.encoder if isinstance(m, nn.Conv2d)
+        )
+        assert n_untied - n_tied == encoder_conv_weights
+
+    def test_tied_forward_matches_functional_reference(self):
+        """The tied decoder produces the same output as a manual F.conv_transpose2d call."""
+        import torch.nn.functional as F
+
+        torch.manual_seed(0)
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        model.eval()
+
+        # Build the reference path manually using each tied layer's encoder weight.
+        x = _ae_input(batch_size=2)
+        with torch.no_grad():
+            actual = model(x)
+            # Re-run forward step by step using F.conv_transpose2d directly.
+            h = model.encoder(x)
+            for m in model.decoder:
+                if isinstance(m, TiedConvTranspose2d):
+                    h = F.conv_transpose2d(
+                        h, m.encoder_conv.weight, m.bias,
+                        stride=m.stride, padding=m.padding,
+                    )
+                else:
+                    h = m(h)
+        assert torch.allclose(actual, h, atol=1e-6)
+
+    def test_encoder_update_visible_to_decoder(self):
+        """Mutating an encoder Conv2d weight changes the decoder's effective filter."""
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        model.eval()
+
+        x = _ae_input(batch_size=1)
+        with torch.no_grad():
+            before = model(x).clone()
+            # Perturb the first encoder Conv2d weight in place.
+            first_conv = next(m for m in model.encoder if isinstance(m, nn.Conv2d))
+            first_conv.weight.add_(0.5)
+            after = model(x)
+        # The decoder reads the encoder weight at forward time, so the output
+        # must change when the encoder weight changes.
+        assert not torch.allclose(before, after)
+
+    def test_gradient_accumulates_into_encoder_weight_from_decoder(self):
+        """Backward through the decoder produces gradients on the tied encoder weights."""
+        torch.manual_seed(0)
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        model.train()
+
+        # Zero all grads, run forward + backward, verify the first encoder
+        # Conv2d weight has a gradient (it could only come via the decoder
+        # since the encoder output is unused as a final loss target here).
+        for p in model.parameters():
+            p.grad = None
+
+        x = _ae_input(batch_size=2)
+        out = model(x)
+        loss = (out ** 2).mean()
+        loss.backward()
+
+        for m in model.encoder:
+            if isinstance(m, nn.Conv2d):
+                assert m.weight.grad is not None
+                assert torch.isfinite(m.weight.grad).all()
+                assert m.weight.grad.abs().sum() > 0
+
+    def test_state_dict_round_trip_preserves_tying(self):
+        """Saving and reloading the tied model keeps the decoder tied to the encoder."""
+        src = DeepFontAE(_small_ae_config(tied_weights=True))
+        dst = DeepFontAE(_small_ae_config(tied_weights=True))
+        dst.load_state_dict(src.state_dict())
+
+        encoder_convs = [m for m in dst.encoder if isinstance(m, nn.Conv2d)]
+        tied_layers = [m for m in dst.decoder if isinstance(m, TiedConvTranspose2d)]
+        for enc, dec in zip(encoder_convs, reversed(tied_layers), strict=True):
+            assert dec.encoder_conv is enc
+
+        # Encoder weights match the source.
+        for src_conv, dst_conv in zip(
+            (m for m in src.encoder if isinstance(m, nn.Conv2d)),
+            encoder_convs,
+            strict=True,
+        ):
+            assert torch.equal(src_conv.weight.data, dst_conv.weight.data)
+
+    def test_tied_output_shape_matches_input(self):
+        """Tied autoencoder reconstructs the same spatial dimensions as input."""
+        model = DeepFontAE(_small_ae_config(tied_weights=True))
+        model.eval()
+        x = _ae_input()
+        with torch.no_grad():
+            out = model(x)
+        assert out.shape == x.shape
+        assert torch.isfinite(out).all()
+
+    def test_loaded_into_classifier_with_tied_ae(self, tmp_path):
+        """Tied AE checkpoints still load into the DeepFont classifier."""
+        weights_path = str(tmp_path / "ae.pt")
+        ae = DeepFontAE(_small_ae_config(tied_weights=True))
+        torch.save(ae.state_dict(), weights_path)
+
+        model = DeepFont(_small_df_config())
+        model.load_encoder_weights(weights_path)
+        # First conv weight should match the AE's first encoder conv weight.
+        df_conv0 = model.encoder[0].weight.data
+        ae_conv0 = next(m for m in ae.encoder if isinstance(m, nn.Conv2d)).weight.data
+        assert torch.equal(df_conv0, ae_conv0)
 
 
 class TestDeepFontInstantiation:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -62,6 +62,10 @@ class TestDeepFontAEConfigDefaults:
         """Default pool kernel size is 2."""
         assert DeepFontAEConfig().pool_kernel_size == 2
 
+    def test_tied_weights_default(self):
+        """Default autoencoder ties decoder weights to the encoder."""
+        assert DeepFontAEConfig().tied_weights is True
+
     def test_output_activation_default(self):
         """Default output activation is None (linear output)."""
         assert DeepFontAEConfig().output_activation is None


### PR DESCRIPTION
Adds a TiedConvTranspose2d module and a tied_weights config flag (default True) so the autoencoder decoder reuses its paired encoder Conv2d weights via F.conv_transpose2d, matching the original Masci 2011 SCAE formulation cited by the DeepFont paper. Existing tests that assumed nn.ConvTranspose2d in the decoder now opt into the untied variant explicitly, and a dedicated TestDeepFontAETiedWeights class covers weight identity, state_dict shape, parameter-count delta, gradient flow, and round-trip behavior.